### PR TITLE
Add dispatch license check workflow and release license settings

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,21 @@
+name: License Check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run cargo-deny license check
+        run: |
+          set -euo pipefail
+          rustup default stable
+          cargo install cargo-deny --locked
+          cargo deny --manifest-path Cargo.toml check --config deny.toml licenses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   release:
     uses: eeekcct/goreleaser-rust-workflow/.github/workflows/release.yml@b299f1ca26515c9e0c29c5f1b54bd902684752af # v0.2.1
+    with:
+      third_party_licenses: true
+      license_check: true
     permissions:
       contents: write
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 .intentionally-empty-file.o
 target/
+third_party_licenses

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,9 @@ builds:
 
 archives:
   - formats: [tar.gz]
+    files:
+      - LICENSE*
+      - third_party_licenses/**
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+[licenses]
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "Unicode-3.0",
+]
+confidence-threshold = 0.8


### PR DESCRIPTION
## Summary
- add workflow_dispatch-based license check CI using cargo-deny
- enable license_check and third_party_licenses in release workflow
- add deny.toml and include license artifacts in goreleaser archives
- ignore generated third_party_licenses directory